### PR TITLE
Convert korosuke613/circleci-demo-ruby-rails to GitHub Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -5,13 +5,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: cimg/ruby:2.7-node
     steps:
     - name: Set up bundler cache
       uses: ruby/setup-ruby@v1.138.0
       with:
-        ruby-version: 3.0.2
+        ruby-version: 2.7
         bundler-cache: true
     - uses: actions/checkout@v3.3.0
     - run: bundle check || bundle install
@@ -27,8 +25,6 @@ jobs:
     - run: yarn install --frozen-lockfile
   test:
     runs-on: ubuntu-latest
-    container:
-      image: cimg/ruby:2.7-node
     services:
       postgres:
         image: postgres:9.5-alpine
@@ -49,7 +45,7 @@ jobs:
     - name: Set up bundler cache
       uses: ruby/setup-ruby@v1.138.0
       with:
-        ruby-version: 3.0.2
+        ruby-version: 2.7
         bundler-cache: true
     - uses: actions/checkout@v3.3.0
     - run: bundle check || bundle install

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Set up bundler cache
       uses: ruby/setup-ruby@v1.138.0
       with:
-        ruby-version: 2.7
+        ruby-version: 2.7.5
         bundler-cache: true
     - uses: actions/checkout@v3.3.0
     - run: bundle check || bundle install
@@ -45,7 +45,7 @@ jobs:
     - name: Set up bundler cache
       uses: ruby/setup-ruby@v1.138.0
       with:
-        ruby-version: 2.7
+        ruby-version: 2.7.5
         bundler-cache: true
     - uses: actions/checkout@v3.3.0
     - run: bundle check || bundle install

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,72 @@
+name: korosuke613/circleci-demo-ruby-rails/build_and_test
+on:
+  push:
+    branches:
+    - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/ruby:2.7-node
+    steps:
+    - name: Set up bundler cache
+      uses: ruby/setup-ruby@v1.138.0
+      with:
+        ruby-version: 3.0.2
+        bundler-cache: true
+    - uses: actions/checkout@v3.3.0
+    - run: bundle check || bundle install
+      env:
+        BUNDLE_DEPLOYMENT: true
+    - id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+    - uses: actions/cache@v3.2.2
+      with:
+        path: "${{ steps.yarn-cache-dir-path.outputs.dir }}"
+        key: "${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}"
+        restore-keys: "${{ runner.os }}-yarn-"
+    - run: yarn install --frozen-lockfile
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: cimg/ruby:2.7-node
+    services:
+      postgres:
+        image: postgres:9.5-alpine
+        env:
+          POSTGRES_USER: circleci-demo-ruby
+          POSTGRES_DB: rails_blog_test
+          POSTGRES_PASSWORD: ''
+    needs:
+    - build
+    env:
+      BUNDLE_JOBS: '3'
+      BUNDLE_RETRY: '3'
+      PGHOST: 127.0.0.1
+      PGUSER: circleci-demo-ruby
+      PGPASSWORD: ''
+      RAILS_ENV: test
+    steps:
+    - name: Set up bundler cache
+      uses: ruby/setup-ruby@v1.138.0
+      with:
+        ruby-version: 3.0.2
+        bundler-cache: true
+    - uses: actions/checkout@v3.3.0
+    - run: bundle check || bundle install
+      env:
+        BUNDLE_DEPLOYMENT: true
+    - id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+    - uses: actions/cache@v3.2.2
+      with:
+        path: "${{ steps.yarn-cache-dir-path.outputs.dir }}"
+        key: "${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}"
+        restore-keys: "${{ runner.os }}-yarn-"
+    - run: yarn install --frozen-lockfile
+    - name: Wait for DB
+      run: dockerize -wait tcp://localhost:5432 -timeout 1m
+    - name: Database setup
+      run: bundle exec rails db:schema:load --trace
+    - run: bundle exec rspec spec --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec/results.xml --format progress
+    - run: bundle exec rubocop --format progress

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,8 +1,7 @@
 name: korosuke613/circleci-demo-ruby-rails/build_and_test
 on:
   push:
-    branches:
-    - master
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pipeline migrated from [CircleCI](https://app.circleci.com/pipelines/github/korosuke613/circleci-demo-ruby-rails) :tada:

## Manual steps

Perform the following steps to complete the migration:

### korosuke613/circleci-demo-ruby-rails/build_and_test
- [ ] Ensure: The correct Ruby version is added to all ruby/setup-ruby actions. A placeholder corresponding to the latest stable ruby version has been set automatically.